### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,6 @@
 name: CI
+permissions:
+  contents: read
 on:
   push:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/microsoft/did-x509/security/code-scanning/1](https://github.com/microsoft/did-x509/security/code-scanning/1)

To fix the problem, explicitly add a `permissions` block to the workflow to restrict the `GITHUB_TOKEN` as much as possible. In this case, since no steps in the workflow require write access to repository contents or other privileged scopes, setting `permissions: contents: read` is the recommended baseline. This can be applied at the workflow level (which affects all jobs by default), or at the job level (which applies only to the specified job). The simplest and clearest fix is to put a top-level `permissions` key after the `name:` block and before `on:`, or after `on:` and before `jobs:`.

No extra methods, imports, or definitions are required; this is a YAML configuration change only within the `.github/workflows/ci.yml` file.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
