### PR TITLE
Reorder and polish spec

### DIFF
--- a/didx509/didx509.py
+++ b/didx509/didx509.py
@@ -276,15 +276,12 @@ def to_jwk(cert: x509.Certificate) -> dict:
 def create_did_document(did: str, chain: List[x509.Certificate]):
     leaf = chain[0]
     doc = {
-        "@context": [
-            "https://www.w3.org/ns/did/v1",
-            "https://w3id.org/security/suites/jws-2020/v1"
-        ],
+        "@context": "https://www.w3.org/ns/cid/v1",
         "id": did,
         "verificationMethod": [
             {
                 "id": f"{did}#0",
-                "type": "JsonWebKey2020",
+                "type": "JsonWebKey",
                 "controller": did,
                 "publicKeyJwk": to_jwk(leaf),
             }
@@ -299,6 +296,7 @@ def create_did_document(did: str, chain: List[x509.Certificate]):
     include_assertion_method = key_usage is None or key_usage.digital_signature
     include_key_agreement = key_usage is None or key_usage.key_agreement
     if include_assertion_method:
+        doc["authentication"] = [f"{did}#0"]
         doc["assertionMethod"] = [f"{did}#0"]
     if include_key_agreement:
         doc["keyAgreement"] = [f"{did}#0"]

--- a/specification.md
+++ b/specification.md
@@ -25,7 +25,7 @@ The did:x509 method takes a simple approach that does not introduce additional i
 
 The main difference to other DID methods is that did:x509 requires a certificate chain to be passed using a new [DID resolution option](https://www.w3.org/TR/did-core/#did-resolution-options) `x509chain` while resolving a DID. This certificate chain is typically embedded in the signing envelope, for example within the `x5c` header parameter of JWS/JWT documents.
 
-Embedding certificate chains in configuration or policy is cumbersome and often too coarse to identify the intended certificate holder.
+Embedding certificate chains in configuration or policy is cumbersome. References to individual chain elements can also be too broad, or too unstable when those elements are short-lived.
 
 did:x509 combines authority pinning with certificate predicates in a compact identifier, for example `request.issuer == "did:x509:..."`.
 

--- a/specification.md
+++ b/specification.md
@@ -86,7 +86,26 @@ For the reference Rego, pass the DID string and parsed certificate-chain JSON as
 ```json
 {
   "did": "<DID>",
-  "chain": "<CertificateChain>"
+  "chain": [
+    {
+      "fingerprint": {
+        "sha256": "<leaf-sha256>"
+      },
+      "subject": {
+        "CN": "Example"
+      },
+      "extensions": {}
+    },
+    {
+      "fingerprint": {
+        "sha256": "<ca-sha256>"
+      },
+      "subject": {
+        "CN": "Example CA"
+      },
+      "extensions": {}
+    }
+  ]
 }
 ```
 
@@ -172,6 +191,7 @@ validate_predicate(name, value) := true if {
         v := urlquery.decode(items[i+1])
     }
     count(subject) >= 1
+    count(subject) == count(items) / 2
     object.subset(input.chain[0].subject, subject) == true
 }
 ```
@@ -185,7 +205,7 @@ san-type           = "email" / "dns" / "uri"
 san-value          = 1*idchar
 ```
 
-`san-type` is the SAN type and must be one of `email`, `dns`, or `uri`. Note that `dn` is not supported. The pair [`<san_type>`, `<san_value>`] is one of the items in `chain[0].extensions.san`.
+`san-type` is the SAN type and must be one of `email`, `dns`, or `uri`. Note that `dn` is not supported. `san-value` is percent-encoded. The pair [`<san_type>`, `<san_value>`] is one of the items in `chain[0].extensions.san`.
 
 Example:
 
@@ -353,7 +373,7 @@ Resolving a did:x509 identifier produces a DID Document with a `JsonWebKey` veri
 
 If the leaf certificate has the key usage bit for `digitalSignature`, or is missing the key usage extension, the DID Document includes `authentication` and `assertionMethod`. If the leaf certificate has the key usage bit for `keyAgreement`, or is missing the key usage extension, the DID Document includes `keyAgreement`. If the leaf certificate includes the key usage extension but has neither `digitalSignature` nor `keyAgreement`, resolution fails.
 
-The JSON-LD representation uses the registered `application/did` media type. The media type is selected by the resolution request, not by the DID string.
+Resolvers can use the registered `application/did` media type, and may also support `application/did+ld+json` or `application/did+json` for compatibility with DID Core 1.0 tooling. The media type is selected by the resolution request, not by the DID string.
 
 The JSON-LD `@context` must define every term used. The example below uses the [Controlled Identifiers v1 context](https://www.w3.org/ns/cid/v1).
 

--- a/specification.md
+++ b/specification.md
@@ -81,35 +81,7 @@ In this example, the identifier pins to a certificate authority using a SHA-256 
 
 Predicate validation is defined in [Rego](https://www.openpolicyagent.org/docs/latest/policy-language/) to avoid ambiguous pseudo-code. This has no bearing on implementations, which can be written in any language.
 
-For the reference Rego, pass the DID string and parsed certificate-chain JSON as:
-
-```json
-{
-  "did": "<DID>",
-  "chain": [
-    {
-      "fingerprint": {
-        "sha256": "<leaf-sha256>"
-      },
-      "subject": {
-        "CN": "Example"
-      },
-      "extensions": {}
-    },
-    {
-      "fingerprint": {
-        "sha256": "<ca-sha256>"
-      },
-      "subject": {
-        "CN": "Example CA"
-      },
-      "extensions": {}
-    }
-  ]
-}
-```
-
-Here, `chain` is derived from the `x509chain` resolution option.
+The input to the Rego runtime is a JSON document: `{"did": "<DID>", "chain": <CertificateChain>}`, where `did` is the DID string and `chain` is the parsed representation of the certificate chain derived from the `x509chain` resolution option.
 
 Core Rego policy:
 
@@ -534,17 +506,24 @@ Stable did:x509 identifiers can enable correlation across transactions, transpar
 
 ## Examples and Test Vectors
 
-Example subject-based DID:
+The following synthetic certificate chain is valid from `2026-01-01T00:00:00Z` through `2126-01-01T00:00:00Z`. Its entries are base64url-encoded DER certificates in leaf-first order; join them with commas to build the `x509chain` resolution option.
 
-`did:x509:0:sha256:WE4P5dd8DnLHSkyHaIjhp4udlkF9LqoKwCvu9gl38jk::subject:C:US:ST:California:O:Example%20Organisation`
+```json
+[
+  "MIIB6jCCAZGgAwIBAgICB9MwCgYIKoZIzj0EAwIwKDEmMCQGA1UEAwwdZGlkOng1MDkgVGVzdCBJbnRlcm1lZGlhdGUgQ0EwIBcNMjYwMTAxMDAwMDAwWhgPMjEyNjAxMDEwMDAwMDBaMCAxHjAcBgNVBAMMFU1pY3Jvc29mdCBDb3Jwb3JhdGlvbjBZMBMGByqGSM49AgEGCCqGSM49AwEHA0IABOEX4qCKPxjG9tYoDQ_sgUQX4GHn9RNzO0RQ7feNac7GOMPjEuFcMH_HKXE5-5blSPjeQ3quHOq9t-bM5wQsW1SjgbAwga0wDAYDVR0TAQH_BAIwADAOBgNVHQ8BAf8EBAMCB4AwEwYDVR0lBAwwCgYIKwYBBQUHAwMwOgYDVR0RBDMwMYERYWxpY2VAZXhhbXBsZS5jb22GHGh0dHBzOi8vZXhhbXBsZS5jb20vd29ya2Zsb3cwPAYKKwYBBAGDvzABAQEB_wQraHR0cHM6Ly90b2tlbi5hY3Rpb25zLmdpdGh1YnVzZXJjb250ZW50LmNvbTAKBggqhkjOPQQDAgNHADBEAiAZ19FXG8b-CfMEHMGuW4Irty2PmnK1FRhG7dQHs3gLIgIgXQj3TqnxGHs5JERYd8k-7jtCN8c8hcwMda9qtANsURE",
+  "MIIBYTCCAQagAwIBAgICB9IwCgYIKoZIzj0EAwIwIDEeMBwGA1UEAwwVZGlkOng1MDkgVGVzdCBSb290IENBMCAXDTI2MDEwMTAwMDAwMFoYDzIxMjYwMTAxMDAwMDAwWjAoMSYwJAYDVQQDDB1kaWQ6eDUwOSBUZXN0IEludGVybWVkaWF0ZSBDQTBZMBMGByqGSM49AgEGCCqGSM49AwEHA0IABCGOU6tOhbKML7y0-bGB-B_p5Rgm0wTn93V4NHVDudiUi-sDkmlX-N5tswsZf0Qd459YdnaqhsWYM2UUo2bgWaCjJjAkMBIGA1UdEwEB_wQIMAYBAf8CAQAwDgYDVR0PAQH_BAQDAgEGMAoGCCqGSM49BAMCA0kAMEYCIQDiLS9MqRBKW-XXpWXBoeUkndfg4nLC70JOibfNz-kgxAIhAMX83RS30hPgJjIuRFXXQyIbcnjFTSv8f27cEwdgcTdS",
+  "MIIBVzCB_qADAgECAgIH0TAKBggqhkjOPQQDAjAgMR4wHAYDVQQDDBVkaWQ6eDUwOSBUZXN0IFJvb3QgQ0EwIBcNMjYwMTAxMDAwMDAwWhgPMjEyNjAxMDEwMDAwMDBaMCAxHjAcBgNVBAMMFWRpZDp4NTA5IFRlc3QgUm9vdCBDQTBZMBMGByqGSM49AgEGCCqGSM49AwEHA0IABHgjQa6wjzl1UbPw_PkxStxPzJD6i62i8IHLyAiQUTMmadClm4O5nZStDAo62cm1kUrBjLQroB746VVaksVeiDajJjAkMBIGA1UdEwEB_wQIMAYBAf8CAQEwDgYDVR0PAQH_BAQDAgEGMAoGCCqGSM49BAMCA0gAMEUCIQD2NQq61OLNOSxpfoVSo4vaPfgNg6UFNXeGVEaR4_r6kgIgPLNbkXnthP6oGlr2CFNZeYsN3DDKm_O9MjloCaVEwDs"
+]
+```
 
-Example SAN-based DID:
+The following DIDs resolve using the certificate chain above:
 
-`did:x509:0:sha256:WE4P5dd8DnLHSkyHaIjhp4udlkF9LqoKwCvu9gl38jk::san:email:bob%40example.com`
-
-Example Fulcio-based DID:
-
-`did:x509:0:sha256:WE4P5dd8DnLHSkyHaIjhp4udlkF9LqoKwCvu9gl38jk::fulcio-issuer:issuer.example.com::san:uri:https%3A%2F%2Fexample.com%2Focto-org%2Focto-automation%2Fworkflows%2Foidc.yml%40refs%2Fheads%2Fmain`
+| Name | DID |
+|---|---|
+| Root CA fingerprint with subject predicate | `did:x509:0:sha256:X11SlCN2S52b4zYqoqpzSpBlizT-JRUqikvLAhyJ_60::subject:CN:Microsoft%20Corporation` |
+| Intermediate CA fingerprint with subject predicate | `did:x509:0:sha256:FpGAHUDNIQ331WfbeH_qNi5sFl49v802hsc0GTXp5Ys::subject:CN:Microsoft%20Corporation` |
+| EKU predicate | `did:x509:0:sha256:X11SlCN2S52b4zYqoqpzSpBlizT-JRUqikvLAhyJ_60::eku:1.3.6.1.5.5.7.3.3` |
+| Fulcio issuer with URI SAN predicate | `did:x509:0:sha256:X11SlCN2S52b4zYqoqpzSpBlizT-JRUqikvLAhyJ_60::fulcio-issuer:token.actions.githubusercontent.com::san:uri:https%3A%2F%2Fexample.com%2Fworkflow` |
 
 ## References
 

--- a/specification.md
+++ b/specification.md
@@ -156,7 +156,7 @@ oid                = 1*DIGIT *("." 1*DIGIT)
 
 Example:
 
-`did:x509:0:sha256:WE4P5dd8DnLHSkyHaIjhp4udlkF9LqoKwCvu9gl38jk::subject:C:US:ST:Texas:L:Austin:O:Example`
+`did:x509:0:sha256:WE4P5dd8DnLHSkyHaIjhp4udlkF9LqoKwCvu9gl38jk::subject:C:US:ST:California:O:Example%20Organisation`
 
 Rego policy:
 
@@ -283,6 +283,8 @@ Each certificate object can contain:
 | `subject` | X.509 subject name, represented as an object of name attributes. |
 | `extensions.eku` | Extended Key Usage OIDs from RFC 5280 Section 4.2.1.12. |
 | `extensions.san` | Subject Alternative Name entries from RFC 5280 Section 4.2.1.6. |
+| `extensions.key_usage` | Key Usage values used to decide verification relationships. |
+| `extensions.basic_constraints` | Whether the certificate is a CA certificate. |
 | `extensions.fulcio_issuer` | The Fulcio issuer extension value. |
 
 Name objects use the RFC 4514 labels `CN`, `L`, `ST`, `O`, `OU`, `C`, and `STREET` for common attributes. Other attributes use dotted OID strings as keys. Repeated attributes are not supported. Values are converted to UTF-8 strings.
@@ -310,15 +312,28 @@ Example certificate chain model:
       "CN": "Example CA"
     },
     "subject": {
-      "CN": "Example",
-      "O": "Example Organisation"
+      "CN": "Example"
     },
     "extensions": {
       "eku": ["1.3.6.1.4.1.311.10.3.13"],
       "san": [
         ["email", "user@example.com"],
-        ["dns", "example.com"]
+        ["dns", "example.com"],
+        ["uri", "https://example.com"],
+        [
+          "dn",
+          {
+            "CN": "Example"
+          }
+        ]
       ],
+      "key_usage": [
+        "digitalSignature",
+        "keyAgreement"
+      ],
+      "basic_constraints": {
+        "ca": false
+      },
       "fulcio_issuer": "https://issuer.example.com"
     }
   },
@@ -334,7 +349,15 @@ Example certificate chain model:
     "subject": {
       "CN": "Example CA"
     },
-    "extensions": {}
+    "extensions": {
+      "key_usage": [
+        "keyCertSign",
+        "cRLSign"
+      ],
+      "basic_constraints": {
+        "ca": true
+      }
+    }
   }
 ]
 ```
@@ -363,9 +386,10 @@ Example DID Document:
       "type": "JsonWebKey",
       "controller": "did:x509:0:sha256:hH32p4SXlD8n_HLrk_mmNzIKArVh0KkbCeh6eAftfGE::subject:CN:Example",
       "publicKeyJwk": {
-        "kty": "RSA",
-        "n": "s9HduD2rvmO-SGksB4HR-qvSK379St8NnUZBH8xBiQvt2zONOLUHWQibeBW4NLUfHfzMaOM77RhNlqPNiDRKhChlG1aHqEHSAaQBGrmr0ULGIzq-1YvqQufMGYBFfq0sc10UdvWqT0RjwkPQTu4bjg37zSYF9OcGxS9uGnPMdWRM0ThOsYUcDmMoCaJRebsLUBpMmYXkcUYXJrcSGAaUNd0wjhwIpEogOD-AbWW_7TPZOl-JciMj40a78EEXIc2p06lWHfe5hegQ7uGIlSAPG6zDzjhjNkzE63_-GoqJU-6QLazbL5_y27ZDUAEYJokbb305A-dOp930CjTar3BvWQ",
-        "e": "AQAB"
+        "kty": "EC",
+        "crv": "P-256",
+        "x": "usNb0QXAk6R76GPFvKT5a46LC0_qRpxNoLn9WAX8K0I",
+        "y": "dTtI2j8aV0Mdk5fNWP9rCJvFIo6QfLjCm8V5v10J4Xg"
       }
     }
   ],

--- a/specification.md
+++ b/specification.md
@@ -290,7 +290,7 @@ Trust is established by validating the certificate chain, matching the CA finger
 
 ## Certificate Chain JSON Model
 
-For predicate evaluation, the resolver maps the certificate chain to a small JSON model. This model contains only the fields did:x509 matches on; it does not replace X.509 parsing or RFC 5280 path validation.
+For predicate evaluation, the resolver maps the certificate chain to a limited JSON model. This model contains only the fields did:x509 matches on; it does not replace X.509 parsing or RFC 5280 path validation.
 
 The model is a JSON array with at least two certificate objects. The leaf certificate is first, followed by issuer certificates, with the root or trust anchor last.
 

--- a/specification.md
+++ b/specification.md
@@ -1,6 +1,10 @@
 # did:x509 Method Specification
 
+## Status, Version, and Authors
+
 Status: DRAFT
+
+Method version: `0`
 
 Authors:
 - Maik Riechert (Microsoft)
@@ -21,73 +25,19 @@ The did:x509 method takes a simple approach that does not introduce additional i
 
 The main difference to other DID methods is that did:x509 requires a certificate chain to be passed using a new [DID resolution option](https://www.w3.org/TR/did-core/#did-resolution-options) `x509chain` while resolving a DID. This certificate chain is typically embedded in the signing envelope, for example within the `x5c` header parameter of JWS/JWT documents.
 
-## Example
+Embedding certificate chains in configuration or policy is cumbersome and often too coarse to identify the intended certificate holder.
 
-`did:x509:0:sha256:WE4P5dd8DnLHSkyHaIjhp4udlkF9LqoKwCvu9gl38jk::subject:C:US:ST:California:O:Example%20Organisation`
+did:x509 combines authority pinning with certificate predicates in a compact identifier, for example `request.issuer == "did:x509:..."`.
 
-In this example, the identifier pins to a certificate authority using the SHA-256 certificate hash and uses the `subject` predicate to express criteria which a leaf certificate's subject must fulfil. This identifier will match any certificate chains with matching leaf certificate subject fields and a matching intermediate or root CA certificate.
+## DID Method Name
 
-## JSON data model for X.509 certificate chains
+The DID method name is `x509`.
 
-This section defines a JSON data model for X.509 certificate chains that is the basis for evaluating whether a certificate chain matches a given did:x509 identifier. The language used for defining the JSON data model is CDDL ([RFC 8610](https://www.rfc-editor.org/rfc/rfc8610)).
+A did:x509 DID starts with `did:x509:` and binds a CA fingerprint to one or more certificate predicates.
 
-```cddl
-CertificateChain = [2*Certificate]  ; leaf is first
+## DID Syntax
 
-Certificate = {
-    fingerprint: {
-        ; base64url-encoded hashes of the DER-encoded certificate
-        sha256: base64url,     ; FIPS 180-4, SHA-256
-        sha384: base64url,     ; FIPS 180-4, SHA-384
-        sha512: base64url      ; FIPS 180-4, SHA-512
-    },
-    issuer: Name,              ; RFC 5280, Section 4.1.2.4
-    subject: Name,             ; RFC 5280, Section 4.1.2.6
-    extensions: {
-        ? eku: [+OID],         ; RFC 5280, Section 4.2.1.12
-        ? san: [+SAN],         ; RFC 5280, Section 4.2.1.6
-        ? fulcio_issuer: tstr  ; http://oid-info.com/get/1.3.6.1.4.1.57264.1.1
-    }
-}
-
-; X.509 Name as an object of attributes
-; Repeated attribute types are not supported
-; Common attribute types have human-readable labels (see below)
-; Other attribute types use dotted OIDs
-; Values are converted to UTF-8
-Name = {
-    ; See RFC 4514, Section 3, for meaning of common attribute types
-    ? CN: tstr,
-    ? L: tstr,
-    ? ST: tstr,
-    ? O: tstr,
-    ? OU: tstr,
-    ? C: tstr,
-    ? STREET: tstr,
-    * OID => tstr
-}
-
-; base64url-encoded data, see RFC 4648, Section 5
-base64url = tstr
-
-; ASN.1 Object Identifier
-; Dotted string, for example "1.2.3"
-OID = tstr
-
-; X.509 Subject Alternative Name
-; Strings are converted to UTF-8
-SAN = rfc822Name / DNSName / URI / DirectoryName
-rfc822Name = ["email", tstr] ; Example: ["email", "user@example.com"]
-DNSName = ["dns", tstr]      ; Example: ["dns", "example.com"]
-URI = ["uri", tstr]          ; Example: ["uri", "https://example.com"]
-DirectoryName = ["dn", Name] ; Example: ["dn", {CN: "Example"}]
-```
-
-In the rest of this document, `chain` refers to the certificate chain mapped to the above JSON data model.
-
-## Identifier Syntax
-
-The did:x509 ABNF definitions below use the syntax in [RFC 5234](https://www.rfc-editor.org/rfc/rfc5234.html) and the corresponding definitions for `ALPHA`, `DIGIT`, and `HEXDIG`. The [W3C DID v1.0 specification](https://www.w3.org/TR/2022/REC-did-core-20220719/) defines `idchar` and `pct-encoded`; those definitions are repeated here for readability.
+The did:x509 ABNF definitions use [RFC 5234](https://www.rfc-editor.org/rfc/rfc5234.html). The DID Core `idchar` and `pct-encoded` definitions are repeated for readability.
 
 ```abnf
 idchar             = ALPHA / DIGIT / "." / "-" / "_" / pct-encoded
@@ -105,25 +55,42 @@ predicate-value    = *(1*idchar ":") 1*idchar
 base64url          = 1*(ALPHA / DIGIT / "-" / "_")
 ```
 
-In this draft, version is `0`.
+The current version value is `0`.
 
-`ca-fingerprint-alg` is one of `sha256`, `sha384`, or `sha512`.
+The `ca-fingerprint-alg` value is one of `sha256`, `sha384`, or `sha512`. The `ca-fingerprint` value is a base64url-encoded digest of a non-leaf certificate in the certificate chain, that is, either an intermediate or root CA certificate.
 
-`ca-fingerprint` is `chain[i].fingerprint[ca-fingerprint-alg]` with i > 0, that is, either an intermediate or root CA certificate.
+The `::` separator introduces predicates. Each predicate has a `predicate-name` and a predicate-specific `predicate-value`.
 
-`predicate-name` is a predicate name and `predicate-value` is a predicate-specific value. 
+## Method-specific Identifier
 
-`::` is used to separate multiple predicates from each other.
+The method-specific identifier has three parts:
+
+1. A version number.
+2. A certificate authority fingerprint algorithm and value.
+3. One or more predicates that match fields in the leaf certificate.
 
 did:x509 does not define any DID URL path or query semantics. A did:x509 DID URL MUST NOT include a path or query component. Fragment identifiers remain valid for identifying resources within a resolved DID document, for example `<DID>#0`.
 
-The following sections define the predicates and their predicate-specific syntax.
+Example:
 
-Validation of predicates is formally defined using policies written in the [Rego language](https://www.openpolicyagent.org/docs/latest/policy-language/), rather than pseudo-code.
-This is to avoid ambiguity and to make it possible for a reader to evaluate the logic automatically, but there is no expectation that implementations use the Rego language.
+`did:x509:0:sha256:WE4P5dd8DnLHSkyHaIjhp4udlkF9LqoKwCvu9gl38jk::subject:C:US:ST:California:O:Example%20Organisation`
 
-The inputs to the resolution process are the DID string itself and the `x509chain` DID resolution option, which carries a comma-separated base64url-encoded X.509 certificate chain.
-To evaluate the reference Rego code shown below, the DID and certificate chain have to be passed to a Rego runtime as a JSON document: `{"did": "<DID>", "chain": <CertificateChain>}`, where `did` is the DID string and `chain` is the parsed representation of the certificate chain derived from the `x509chain` resolution option.
+In this example, the identifier pins to a certificate authority using a SHA-256 certificate hash and uses the `subject` predicate to express criteria that a leaf certificate subject must fulfil. This identifier will match certificate chains with matching leaf certificate subject fields and a matching intermediate or root CA certificate.
+
+### Predicate validation model
+
+Predicate validation is defined in [Rego](https://www.openpolicyagent.org/docs/latest/policy-language/) to avoid ambiguous pseudo-code. Implementations do not have to use Rego.
+
+For the reference Rego, pass the DID string and parsed certificate-chain JSON as:
+
+```json
+{
+  "did": "<DID>",
+  "chain": "<CertificateChain>"
+}
+```
+
+Here, `chain` is derived from the `x509chain` resolution option.
 
 Core Rego policy:
 
@@ -166,23 +133,23 @@ The overall Rego policy is assembled by concatenating the core Rego policy with 
 
 ### Percent-encoding
 
-Some of the predicates that are defined in subsequent sections require values to be percent-encoded. Percent-encoding is specified in [RFC 3986 Section 2.1](https://www.rfc-editor.org/rfc/rfc3986#section-2.1). All characters that are not in the allowed set defined below must be percent-encoded:
+Some predicates require values to be percent-encoded. Percent-encoding is specified in [RFC 3986 Section 2.1](https://www.rfc-editor.org/rfc/rfc3986#section-2.1). All characters that are not in the allowed set below must be percent-encoded:
 
 ```abnf
 allowed = ALPHA / DIGIT / "-" / "." / "_"
 ```
 
-Note that most libraries implement percent-encoding in the context of URLs and do NOT encode `~` (`%7E`).
+Note that most libraries implement percent-encoding in the context of URLs and do not encode `~` (`%7E`).
 
-### "subject" predicate
+### `subject` predicate
 
 ```abnf
 predicate-name     = "subject"
 predicate-value    = key ":" value *(":" key ":" value)
-key             = label / oid
-value           = 1*idchar
-label           = "CN" / "L" / "ST" / "O" / "OU" / "C" / "STREET"
-oid             = 1*DIGIT *("." 1*DIGIT)
+key                = label / oid
+value              = 1*idchar
+label              = "CN" / "L" / "ST" / "O" / "OU" / "C" / "STREET"
+oid                = 1*DIGIT *("." 1*DIGIT)
 ```
 
 `<key>:<value>` are the subject name fields in `chain[0].subject` in any order. Key repetitions are not allowed. Values must be percent-encoded.
@@ -192,6 +159,7 @@ Example:
 `did:x509:0:sha256:WE4P5dd8DnLHSkyHaIjhp4udlkF9LqoKwCvu9gl38jk::subject:C:US:ST:Texas:L:Austin:O:Example`
 
 Rego policy:
+
 ```rego
 validate_predicate(name, value) := true if {
     name == "subject"
@@ -208,26 +176,23 @@ validate_predicate(name, value) := true if {
 }
 ```
 
-### "san" predicate
+### `san` predicate
 
 ```abnf
 predicate-name     = "san"
 predicate-value    = san-type ":" san-value
-san-type        = "email" / "dns" / "uri"
-san-value       = 1*idchar
+san-type           = "email" / "dns" / "uri"
+san-value          = 1*idchar
 ```
 
-`san-type` is the SAN type and must be one of `email`, `dns`, or `uri`. Note that `dn` is not supported.
+`san-type` is the SAN type and must be one of `email`, `dns`, or `uri`. Note that `dn` is not supported. The pair [`<san_type>`, `<san_value>`] is one of the items in `chain[0].extensions.san`.
 
-`san-value` is the SAN value, percent-encoded.
-
-The pair [`<san_type>`, `<san_value>`] is one of the items in `chain[0].extensions.san`.
-
-Example: 
+Example:
 
 `did:x509:0:sha256:WE4P5dd8DnLHSkyHaIjhp4udlkF9LqoKwCvu9gl38jk::san:email:bob%40example.com`
 
 Rego policy:
+
 ```rego
 validate_predicate(name, value) := true if {
     name == "san"
@@ -237,13 +202,13 @@ validate_predicate(name, value) := true if {
 }
 ```
 
-### "eku" predicate
+### `eku` predicate
 
 ```abnf
-predicate-name  = "eku"
-predicate-value = eku
-eku          = oid
-oid          = 1*DIGIT *("." 1*DIGIT)
+predicate-name     = "eku"
+predicate-value    = eku
+eku                = oid
+oid                = 1*DIGIT *("." 1*DIGIT)
 ```
 
 `eku` is one of the OIDs within `chain[0].extensions.eku`.
@@ -253,6 +218,7 @@ Example:
 `did:x509:0:sha256:WE4P5dd8DnLHSkyHaIjhp4udlkF9LqoKwCvu9gl38jk::eku:1.3.6.1.4.1.311.10.3.13`
 
 Rego policy:
+
 ```rego
 validate_predicate(name, value) := true if {
     name == "eku"
@@ -260,15 +226,15 @@ validate_predicate(name, value) := true if {
 }
 ```
 
-### "fulcio-issuer" predicate
+### `fulcio-issuer` predicate
 
 ```abnf
-predicate-name   = "fulcio-issuer"
-predicate-value  = fulcio-issuer
-fulcio-issuer = 1*idchar
+predicate-name     = "fulcio-issuer"
+predicate-value    = fulcio-issuer
+fulcio-issuer      = 1*idchar
 ```
 
-`fulcio-issuer` is `chain[0].extensions.fulcio_issuer`, without leading `https://`, percent-encoded. 
+`fulcio-issuer` is `chain[0].extensions.fulcio_issuer`, without leading `https://`, percent-encoded.
 
 Example:
 
@@ -279,6 +245,7 @@ Example 2:
 `did:x509:0:sha256:WE4P5dd8DnLHSkyHaIjhp4udlkF9LqoKwCvu9gl38jk::fulcio-issuer:issuer.example.com::san:uri:https%3A%2F%2Fexample.com%2Focto-org%2Focto-automation%2Fworkflows%2Foidc.yml%40refs%2Fheads%2Fmain`
 
 Rego policy:
+
 ```rego
 validate_predicate(name, value) := true if {
     name == "fulcio-issuer"
@@ -287,35 +254,113 @@ validate_predicate(name, value) := true if {
 }
 ```
 
-## DID resolution options
+## Verifiable Data Registry and Trust Model
 
-This DID method introduces a new DID resolution option called `x509chain`:
+did:x509 does not define a persistent registry of DID Documents. Resolution uses the DID string and the `x509chain` resolution option.
 
-Name: `x509chain`
+The `x509chain` option carries the certificate chain as a comma-separated list of base64url-encoded DER certificates:
 
-Value type: string
+```text
+x509chain = b64url(DER(leaf)) "," b64url(DER(intermediate)) "," b64url(DER(root))
+```
 
-The value is constructed as follows:
+The chain is ordered leaf first and root or trust anchor last. Each comma-separated item is the DER encoding of one complete X.509 certificate, not a public key, fingerprint, or DER encoding of the whole chain.
 
-1. Encode each certificate `C` that is part of the chain as the string `b64url(DER(C))`.
+Trust is established by validating the certificate chain, matching the CA fingerprint, and validating the predicates against the leaf certificate. Applications can add revocation, certificate transparency, signing time, or endorsement checks.
 
-2. Concatenate the resulting strings in order, separated by comma `","`.
+## Certificate Chain JSON Model
 
-## Example DID Document
+For predicate evaluation, the resolver maps the certificate chain to a small JSON model. This model contains only the fields did:x509 matches on; it does not replace X.509 parsing or RFC 5280 path validation.
 
-This illustrates what a typical [DID Document](https://www.w3.org/TR/did-core/#dfn-did-documents), describing the DID subject and the methods it can use to authenticate itself, can look like once resolved:
+The model is a JSON array with at least two certificate objects. The leaf certificate is first, followed by issuer certificates, with the root or trust anchor last.
+
+Each certificate object can contain:
+
+| Field | Meaning |
+|---|---|
+| `fingerprint` | Base64url-encoded hashes of the DER-encoded certificate, keyed by `sha256`, `sha384`, and `sha512`. |
+| `issuer` | X.509 issuer name, represented as an object of name attributes. |
+| `subject` | X.509 subject name, represented as an object of name attributes. |
+| `extensions.eku` | Extended Key Usage OIDs from RFC 5280 Section 4.2.1.12. |
+| `extensions.san` | Subject Alternative Name entries from RFC 5280 Section 4.2.1.6. |
+| `extensions.fulcio_issuer` | The Fulcio issuer extension value. |
+
+Name objects use the RFC 4514 labels `CN`, `L`, `ST`, `O`, `OU`, `C`, and `STREET` for common attributes. Other attributes use dotted OID strings as keys. Repeated attributes are not supported. Values are converted to UTF-8 strings.
+
+SAN entries are arrays. The first item identifies the SAN type, and the second item is the value:
+
+| SAN type | JSON shape |
+|---|---|
+| RFC 822 name | `["email", "user@example.com"]` |
+| DNS name | `["dns", "example.com"]` |
+| URI | `["uri", "https://example.com"]` |
+| Directory name | `["dn", {"CN": "Example"}]` |
+
+Example certificate chain model:
+
+```json
+[
+  {
+    "fingerprint": {
+      "sha256": "leaf-sha256",
+      "sha384": "leaf-sha384",
+      "sha512": "leaf-sha512"
+    },
+    "issuer": {
+      "CN": "Example CA"
+    },
+    "subject": {
+      "CN": "Example",
+      "O": "Example Organisation"
+    },
+    "extensions": {
+      "eku": ["1.3.6.1.4.1.311.10.3.13"],
+      "san": [
+        ["email", "user@example.com"],
+        ["dns", "example.com"]
+      ],
+      "fulcio_issuer": "https://issuer.example.com"
+    }
+  },
+  {
+    "fingerprint": {
+      "sha256": "ca-sha256",
+      "sha384": "ca-sha384",
+      "sha512": "ca-sha512"
+    },
+    "issuer": {
+      "CN": "Example Root CA"
+    },
+    "subject": {
+      "CN": "Example CA"
+    },
+    "extensions": {}
+  }
+]
+```
+
+In the rest of this document, `chain` refers to the certificate chain mapped to this JSON model.
+
+## DID Document Shape
+
+Resolving a did:x509 identifier produces a DID Document with a `JsonWebKey` verification method derived from the leaf certificate public key.
+
+If the leaf certificate has the key usage bit for `digitalSignature`, or is missing the key usage extension, the DID Document includes `authentication` and `assertionMethod`. If the leaf certificate has the key usage bit for `keyAgreement`, or is missing the key usage extension, the DID Document includes `keyAgreement`. If the leaf certificate includes the key usage extension but has neither `digitalSignature` nor `keyAgreement`, resolution fails.
+
+The JSON-LD representation uses the registered `application/did` media type. The media type is selected by the resolution request, not by the DID string.
+
+The JSON-LD `@context` must define every term used. The example below uses the [Controlled Identifiers v1 context](https://www.w3.org/ns/cid/v1).
+
+Example DID Document:
 
 ```json
 {
-  "@context": [
-    "https://www.w3.org/ns/did/v1",
-    "https://w3id.org/security/suites/jws-2020/v1"
-  ],
+  "@context": "https://www.w3.org/ns/cid/v1",
   "id": "did:x509:0:sha256:hH32p4SXlD8n_HLrk_mmNzIKArVh0KkbCeh6eAftfGE::subject:CN:Example",
   "verificationMethod": [
     {
       "id": "did:x509:0:sha256:hH32p4SXlD8n_HLrk_mmNzIKArVh0KkbCeh6eAftfGE::subject:CN:Example#0",
-      "type": "JsonWebKey2020",
+      "type": "JsonWebKey",
       "controller": "did:x509:0:sha256:hH32p4SXlD8n_HLrk_mmNzIKArVh0KkbCeh6eAftfGE::subject:CN:Example",
       "publicKeyJwk": {
         "kty": "RSA",
@@ -323,6 +368,9 @@ This illustrates what a typical [DID Document](https://www.w3.org/TR/did-core/#d
         "e": "AQAB"
       }
     }
+  ],
+  "authentication": [
+    "did:x509:0:sha256:hH32p4SXlD8n_HLrk_mmNzIKArVh0KkbCeh6eAftfGE::subject:CN:Example#0"
   ],
   "assertionMethod": [
     "did:x509:0:sha256:hH32p4SXlD8n_HLrk_mmNzIKArVh0KkbCeh6eAftfGE::subject:CN:Example#0"
@@ -333,95 +381,99 @@ This illustrates what a typical [DID Document](https://www.w3.org/TR/did-core/#d
 }
 ```
 
-## Operations
+## Method Operations
 
 ### Create
 
-Creating a did:x509 identifier is a local operation. The DID must be constructed according to the syntax rules in the previous sections. No other actions are required.
+Creating a did:x509 identifier is a local operation. The DID must be constructed according to the syntax rules in this specification. No registration action is required.
 
-When constructing a did:x509, the first step is to determine what constitutes a logical identity within a given certificate authority. Concretely, which certificate fields does an authority use to uniquely represent an identity. After that, one or more matching predicates must be chosen that allow to express such an identity as faithfully as possible.
+When constructing a did:x509 identifier, determine what constitutes a logical identity within a given certificate authority. Concretely, determine which certificate fields the authority uses to uniquely represent an identity. After that, choose one or more matching predicates that express such an identity as faithfully as possible.
 
-As an example, a certificate authority may exclusively use email addresses as a way to separate identities, and it may use the SAN extension to store the email address. In that case, the did:x509 identifier should be constructed using the `san` predicate, for example, `did:x509:0:sha256:<ca-fingerprint>::san:email:bob%40example.com`. The certificate may contain other information about the identity, like full name and address, but the primary field that uniquely identifies the identity in this case is just the email address.
+As an example, a certificate authority may use email addresses as a way to separate identities and use the SAN extension to store the email address. In that case, the did:x509 identifier should be constructed using the `san` predicate, for example, `did:x509:0:sha256:<ca-fingerprint>::san:email:bob%40example.com`.
 
 In other cases, an authority may not include email addresses at all and instead rely on a specific set of subject fields to separate identities. In that case, the `subject` predicate should be used.
 
 In yet other cases, authorities may assign unique numbers or other types of stable identifiers to logical identities. Typically, this is done to have a stable reference even if a person changes their name or email address.
 
-In all cases, the goal is to craft a did:x509 that is both stable yet not too loose in its predicates. An example of a loose did:x509 may be to use the `subject` predicate and only include the `O` field without location fields like country (`C`) or state/locality (`ST`). See also the Security and Privacy Considerations sections.
+In all cases, the goal is to craft a did:x509 identifier that is stable yet not too loose in its predicates. An example of a loose did:x509 identifier may be to use the `subject` predicate and only include the `O` field without location fields like country (`C`) or state/locality (`ST`).
 
-Finally, whether a did:x509 should pin to an intermediate CA instead of a root CA (via the certificate fingerprint) depends on whether there is value in distinguishing between them. Pinning to an intermediate CA typically means that the lifetime of the did:x509 will be shorter, since intermediate CA certificates typically have a shorter validity period than root CA certificates.
+Whether a did:x509 identifier should pin to an intermediate CA instead of a root CA depends on whether there is value in distinguishing between them. Pinning to an intermediate CA typically means that the lifetime of the did:x509 identifier will be shorter, since intermediate CA certificates typically have a shorter validity period than root CA certificates.
 
-### Read
+### Read / Resolve
 
-The Read operation takes as input a DID to resolve, together with the `x509chain` DID resolution option.
+The Read operation is DID resolution. The operation takes as input a DID to resolve, together with the `x509chain` DID resolution option.
 
-The following steps must be used to generate a corresponding DID document:
+The DID resolver uses the DID, the certificate chain, and the process in the DID Resolution section to generate a DID Document.
+
+### Update
+
+This DID method does not support updating the DID Document, assuming a fixed certificate chain.
+
+However, the public key included in the DID Document varies depending on the certificate chain that was used as input to the DID resolution process. Typically, multiple chains, in particular leaf certificates, are valid for a given did:x509 identifier.
+
+### Deactivate
+
+This DID method does not support deactivating the DID.
+
+However, if the certificate authority revokes all certificates for the matching DID, or they expire, and does not issue new certificates matching the same DID, then this can be considered equivalent to deactivation of the DID. There is no technical guarantee in this case and the certificate authority can revert its decision.
+
+## DID Resolution
+
+The following steps must be used to generate a corresponding DID Document:
 
 1. Decode the `x509chain` resolution option value into individual certificates by splitting the string on `","` and base64url-decoding each resulting string. The result is a list of DER-encoded certificates that can be loaded in standard libraries. Fail if the list contains fewer than two certificates.
 
-2. Check whether the list of certificates form a valid certificate chain using the [RFC 5280 certification path validation](https://www.rfc-editor.org/rfc/rfc5280#section-6) procedures with the last certificate in the chain as trust anchor. Implementations MUST perform RFC 5280 certification path validation, except that they MUST treat the `fulcio_issuer` extension as recognized for purposes of critical-extension processing. Additionally, fail if any certificate in the chain contains a critical extension that is neither (a) one of the extensions represented in the JSON data model (`eku`, `san`, `fulcio_issuer`), nor (b) one of the following standard RFC 5280 extensions: `basicConstraints`, `keyUsage`, `nameConstraints`, `policyConstraints`, `policyMappings`, `certificatePolicies`, `inhibitAnyPolicy`.
+2. Check whether the list of certificates forms a valid certificate chain using [RFC 5280 certification path validation](https://www.rfc-editor.org/rfc/rfc5280#section-6) procedures with the last certificate in the chain as trust anchor. Implementations MUST perform RFC 5280 certification path validation, except that they MUST treat the `fulcio_issuer` extension as recognized for purposes of critical-extension processing. Additionally, fail if any certificate in the chain contains a critical extension that is neither (a) one of the extensions represented in the JSON model (`eku`, `san`, `fulcio_issuer`), nor (b) one of the following standard RFC 5280 extensions: `basicConstraints`, `keyUsage`, `nameConstraints`, `policyConstraints`, `policyMappings`, `certificatePolicies`, `inhibitAnyPolicy`.
 
-3. If required by the application, check whether any certificate in the chain is revoked (using CRL, OCSP, or other mechanisms).
+3. If required by the application, check whether any certificate in the chain is revoked using CRL, OCSP, or other mechanisms.
 
 4. Apply any further application-specific checks, for example disallowing insecure certificate signature algorithms.
 
-5. Map the certificate chain to the JSON data model.
+5. Map the certificate chain to the JSON model.
 
-6. Check whether the DID is valid against the certificate chain in the JSON data model according to the Rego policy (or equivalent rules) defined in this document.
+6. Check whether the DID is valid against the certificate chain in the JSON model according to the Rego policy or equivalent rules defined in this document.
 
 7. Extract the public key of the first certificate in the chain.
 
 8. Convert the public key to a JSON Web Key.
 
-9. Create the following partial DID document:
+9. Create the following partial DID Document:
 
 ```json
 {
-    "@context": [
-        "https://www.w3.org/ns/did/v1",
-        "https://w3id.org/security/suites/jws-2020/v1"
-    ],
-    "id": "<DID>",
-    "verificationMethod": [{
-        "id": "<DID>#0",
-        "type": "JsonWebKey2020",
-        "controller": "<DID>",
-        "publicKeyJwk": {
-            // JSON Web Key
-        }
-    }]
+  "@context": "https://www.w3.org/ns/cid/v1",
+  "id": "<DID>",
+  "verificationMethod": [{
+    "id": "<DID>#0",
+    "type": "JsonWebKey",
+    "controller": "<DID>",
+    "publicKeyJwk": {
+      "kty": "<JWK key type>"
+    }
+  }]
 }
 ```
 
-10. If the first certificate in the chain has the key usage bit position for `digitalSignature` set or is missing the key usage extension, add the following to the DID document:
+10. If the first certificate in the chain has the key usage bit position for `digitalSignature` set or is missing the key usage extension, add the following to the DID Document:
 
 ```json
 {
-    "assertionMethod": ["<DID>#0"]
+  "authentication": ["<DID>#0"],
+  "assertionMethod": ["<DID>#0"]
 }
 ```
 
-11. If the first certificate in the chain has the key usage bit position for `keyAgreement` set or is missing the key usage extension, add the following to the DID document:
+11. If the first certificate in the chain has the key usage bit position for `keyAgreement` set or is missing the key usage extension, add the following to the DID Document:
 
 ```json
 {
-    "keyAgreement": ["<DID>#0"]
+  "keyAgreement": ["<DID>#0"]
 }
 ```
 
 12. If the first certificate in the chain includes the key usage extension but has neither `digitalSignature` nor `keyAgreement` set as key usage bits, fail.
 
-13. Return the complete DID document.
-
-### Update
-
-This DID Method does not support updating the DID Document, assuming a fixed certificate chain.
-However, the public key included in the DID Document varies depending on the certificate chain that was used as input to the DID resolution process. Typically, multiple chains, in particular leaf certificates, are valid for a given did:x509.
-
-### Deactivate
-
-This DID Method does not support deactivating the DID.
-However, if the certificate authority revokes all certificates for the matching DID (or they expire) and does not issue new certificates matching the same DID, then this can be considered equivalent to deactivation of the DID, though there is no technical guarantee in this case and the certificate authority can revert its decision.
+13. Return the complete DID Document.
 
 ## Security Considerations
 
@@ -429,15 +481,15 @@ However, if the certificate authority revokes all certificates for the matching 
 
 This DID method maps characteristics of X.509 certificate chains to identifiers. It allows a single identifier to map to multiple certificate chains, giving the identifier stability across the expiry of individual chains. However, if the predicates used in the identifier are chosen too loosely, the identifier may match too wide a set of certificate chains. This may have security implications as it may authorize an identity for actions it was not meant to be authorized for.
 
-To mitigate this issue, the certificate authority should publish their expected usage of certificate fields and indicate which ones constitute a unique identity, versus any additional fields that may be of an informational nature. This will help users create an appropriate did:x509 as well as consumers of signed content to decide whether it is appropriate to trust a given did:x509.
+To mitigate this issue, the certificate authority should publish their expected usage of certificate fields and indicate which ones constitute a unique identity, versus any additional fields that may be of an informational nature. This will help users create an appropriate did:x509 identifier as well as consumers of signed content to decide whether it is appropriate to trust a given did:x509 identifier.
 
 ### X.509 trust stores
 
-Typically, a verifier trusts an X.509 certificate by applying [chain validation](https://www.rfc-editor.org/rfc/rfc5280#section-6) (RFC 5280) using a set of certificate authority (CA) certificates as trust store, together with additional application-specific policies.
+Typically, a verifier trusts an X.509 certificate by applying [chain validation](https://www.rfc-editor.org/rfc/rfc5280#section-6) using a set of certificate authority certificates as trust store, together with additional application-specific policies.
 
 This DID method does not require an X.509 trust anchor store but rather relies on verifiers either trusting an individual DID directly or using third-party endorsements for a given DID, like [W3C Verifiable Credentials](https://www.w3.org/TR/vc-data-model/), to establish trust.
 
-By layering this DID method on top of X.509, verifiers are free to use traditional chain validation (for example, verifiers unaware of DID), or rely on DID as an ecosystem to establish trust.
+By layering this DID method on top of X.509, verifiers are free to use traditional chain validation, for example verifiers unaware of DID, or rely on DID as an ecosystem to establish trust.
 
 ### Use of identifier contents
 
@@ -447,9 +499,25 @@ Specifically, extracting and relying upon subject names, organizational informat
 
 ## Privacy Considerations
 
-did:x509 identifiers can include values derived from certificate subject fields and subject alternative names. If these values include personal data (for example, full names or email addresses), publishing or reusing the same identifier across contexts can increase correlatability and expose more information than intended.
+The did:x509 identifier can contain certificate subject names, subject alternative names, extended key usage values, Fulcio issuer values, and a certificate authority fingerprint. These values can reveal personal names, email addresses, domain names, organizational affiliations, credential issuers, or other identifying information. DID creators should choose predicates that are specific enough for relying-party policy but disclose no more certificate attributes than necessary.
 
-To reduce privacy risks, implementers and certificate authorities should minimize identifier contents to fields strictly required for uniqueness and avoid including unnecessary personal information in predicates.
+The `x509chain` resolution option carries the certificate chain used as resolution evidence. Certificates can contain additional metadata beyond the predicates encoded in the DID, including subject attributes, SAN entries, validity periods, certificate policies, and extension values. Resolvers and verifiers should treat certificate chains as potentially identifying data, avoid unnecessary logging or redistribution, and apply data minimization when retaining resolution inputs or outputs.
+
+Stable did:x509 identifiers can enable correlation across transactions, transparency logs, ledgers, and verifiable credentials. If unlinkability is required, relying parties should avoid reusing the same did:x509 identifier across contexts, and issuers should prefer predicates based on role- or service-specific identifiers rather than human-identifying certificate fields.
+
+## Examples and Test Vectors
+
+Example subject-based DID:
+
+`did:x509:0:sha256:WE4P5dd8DnLHSkyHaIjhp4udlkF9LqoKwCvu9gl38jk::subject:C:US:ST:California:O:Example%20Organisation`
+
+Example SAN-based DID:
+
+`did:x509:0:sha256:WE4P5dd8DnLHSkyHaIjhp4udlkF9LqoKwCvu9gl38jk::san:email:bob%40example.com`
+
+Example Fulcio-based DID:
+
+`did:x509:0:sha256:WE4P5dd8DnLHSkyHaIjhp4udlkF9LqoKwCvu9gl38jk::fulcio-issuer:issuer.example.com::san:uri:https%3A%2F%2Fexample.com%2Focto-org%2Focto-automation%2Fworkflows%2Foidc.yml%40refs%2Fheads%2Fmain`
 
 ## References
 
@@ -457,15 +525,13 @@ To reduce privacy risks, implementers and certificate authorities should minimiz
 
 [Decentralized Identifiers (DIDs) v1.0](https://www.w3.org/TR/2022/REC-did-core-20220719/). Manu Sporny, Amy Guy, Markus Sabadello, Drummond Reed. W3C. 19 July 2022. W3C Recommendation.
 
-[RFC 8610 - Concise Data Definition Language (CDDL)](https://www.rfc-editor.org/rfc/rfc8610). H. Birkholz, C. Vigano, C. Bormann. IETF. June 2019. Proposed Standard.
-
 [RFC 5280 - Internet X.509 Public Key Infrastructure Certificate and Certificate Revocation List (CRL) Profile](https://www.rfc-editor.org/rfc/rfc5280). D. Cooper, S. Santesson, S. Farrell, S. Boeyen, R. Housley, W. Polk. IETF. May 2008. Proposed Standard.
 
 [RFC 4514 - Lightweight Directory Access Protocol (LDAP): String Representation of Distinguished Names](https://www.rfc-editor.org/rfc/rfc4514). K. Zeilenga. IETF. June 2006. Proposed Standard.
 
 [RFC 4648 - The Base16, Base32, and Base64 Data Encodings](https://www.rfc-editor.org/rfc/rfc4648). S. Josefsson. IETF. October 2006. Proposed Standard.
 
-[RFC 5234 - Augmented BNF for Syntax Specifications: ABNF](https://www.rfc-editor.org/rfc/rfc5234.html). D. Crocker, P. Overell. IETF. January 2008.  Internet Standard.
+[RFC 5234 - Augmented BNF for Syntax Specifications: ABNF](https://www.rfc-editor.org/rfc/rfc5234.html). D. Crocker, P. Overell. IETF. January 2008. Internet Standard.
 
 [RFC 3986 - Uniform Resource Identifier (URI): Generic Syntax](https://www.rfc-editor.org/rfc/rfc3986). T. Berners-Lee, R. Fielding, L. Masinter. IETF. January 2005. Internet Standard.
 
@@ -473,7 +539,13 @@ To reduce privacy risks, implementers and certificate authorities should minimiz
 
 ### Informative references
 
-[Analysis of hybrid wallet solutions - Implementation options for combining x509 certificates with DIDs and VCs](https://github.com/WebOfTrustInfo/rwot11-the-hague/blob/master/advance-readings/hybrid_wallet_solutions_x509_DIDs_VCs.md). Carsten Stöcker (Spherity) and Christiane Wirrig (Spherity) with support of Paul Bastian (Bundesdruckerei) and Steffen Schwalm (msg Group) in the IDunion Project. 20 July 2022. RWOT11 topic paper.
+[Analysis of hybrid wallet solutions - Implementation options for combining x509 certificates with DIDs and VCs](https://github.com/WebOfTrustInfo/rwot11-the-hague/blob/master/advance-readings/hybrid_wallet_solutions_x509_DIDs_VCs.md). Carsten Stoecker (Spherity) and Christiane Wirrig (Spherity) with support of Paul Bastian (Bundesdruckerei) and Steffen Schwalm (msg Group) in the IDunion Project. 20 July 2022. RWOT11 topic paper.
+
+[RFC 9360 - CBOR Object Signing and Encryption (COSE): Header Parameters for Carrying and Referencing X.509 Certificates](https://www.rfc-editor.org/rfc/rfc9360). J. Schaad. IETF. February 2023. Proposed Standard.
+
+[RFC 9597 - CBOR Web Token (CWT) Claims in COSE Headers](https://www.rfc-editor.org/rfc/rfc9597). M. Jones. IETF. June 2024. Proposed Standard.
+
+[RFC 7519 - JSON Web Token (JWT)](https://www.rfc-editor.org/rfc/rfc7519). M. Jones, J. Bradley, N. Sakimura. IETF. May 2015. Proposed Standard.
 
 [Verifiable Credentials Data Model v1.1](https://www.w3.org/TR/2022/REC-vc-data-model-20220303/). Manu Sporny, Dave Longley, David Chadwick. W3C. 03 March 2022. W3C Recommendation.
 

--- a/specification.md
+++ b/specification.md
@@ -59,7 +59,7 @@ The current version value is `0`.
 
 The `ca-fingerprint-alg` value is one of `sha256`, `sha384`, or `sha512`. The `ca-fingerprint` value is a base64url-encoded digest of a non-leaf certificate in the certificate chain, that is, either an intermediate or root CA certificate.
 
-The `::` separator introduces predicates. Each predicate has a `predicate-name` and a predicate-specific `predicate-value`.
+The `::` separator introduces predicates. Each predicate has a `predicate-name` and a `predicate-value`.
 
 ## Method-specific Identifier
 

--- a/specification.md
+++ b/specification.md
@@ -79,7 +79,7 @@ In this example, the identifier pins to a certificate authority using a SHA-256 
 
 ### Predicate validation model
 
-Predicate validation is defined in [Rego](https://www.openpolicyagent.org/docs/latest/policy-language/) to avoid ambiguous pseudo-code. Implementations do not have to use Rego.
+Predicate validation is defined in [Rego](https://www.openpolicyagent.org/docs/latest/policy-language/) to avoid ambiguous pseudo-code. This has no bearing on implementations, which can be written in any language.
 
 For the reference Rego, pass the DID string and parsed certificate-chain JSON as:
 

--- a/specification.md
+++ b/specification.md
@@ -424,7 +424,7 @@ In yet other cases, authorities may assign unique numbers or other types of stab
 
 In all cases, the goal is to craft a did:x509 identifier that is stable yet not too loose in its predicates. An example of a loose did:x509 identifier may be to use the `subject` predicate and only include the `O` field without location fields like country (`C`) or state/locality (`ST`).
 
-Whether a did:x509 identifier should pin to an intermediate CA instead of a root CA depends on whether there is value in distinguishing between them. Pinning to an intermediate CA typically means that the lifetime of the did:x509 identifier will be shorter, since intermediate CA certificates typically have a shorter validity period than root CA certificates.
+Whether a did:x509 identifier should pin to an intermediate CA instead of a root CA depends on whether there is value in distinguishing between them. Pinning to an intermediate CA typically means that the lifetime of the did:x509 identifier will be shorter, since intermediate CA certificates usually have a shorter validity period than root CA certificates.
 
 ### Read / Resolve
 

--- a/specification.md
+++ b/specification.md
@@ -50,7 +50,7 @@ method-specific-id = version ":" ca-fingerprint-alg ":" ca-fingerprint 1*("::" p
 version            = 1*DIGIT
 ca-fingerprint-alg = "sha256" / "sha384" / "sha512"
 ca-fingerprint     = base64url
-predicate-name     = 1*ALPHA
+predicate-name     = "subject" / "san" / "eku" / "fulcio-issuer"
 predicate-value    = *(1*idchar ":") 1*idchar
 base64url          = 1*(ALPHA / DIGIT / "-" / "_")
 ```
@@ -283,8 +283,6 @@ Each certificate object can contain:
 | `subject` | X.509 subject name, represented as an object of name attributes. |
 | `extensions.eku` | Extended Key Usage OIDs from RFC 5280 Section 4.2.1.12. |
 | `extensions.san` | Subject Alternative Name entries from RFC 5280 Section 4.2.1.6. |
-| `extensions.key_usage` | Key Usage values used to decide verification relationships. |
-| `extensions.basic_constraints` | Whether the certificate is a CA certificate. |
 | `extensions.fulcio_issuer` | The Fulcio issuer extension value. |
 
 Name objects use the RFC 4514 labels `CN`, `L`, `ST`, `O`, `OU`, `C`, and `STREET` for common attributes. Other attributes use dotted OID strings as keys. Repeated attributes are not supported. Values are converted to UTF-8 strings.
@@ -327,13 +325,6 @@ Example certificate chain model:
           }
         ]
       ],
-      "key_usage": [
-        "digitalSignature",
-        "keyAgreement"
-      ],
-      "basic_constraints": {
-        "ca": false
-      },
       "fulcio_issuer": "https://issuer.example.com"
     }
   },
@@ -349,15 +340,7 @@ Example certificate chain model:
     "subject": {
       "CN": "Example CA"
     },
-    "extensions": {
-      "key_usage": [
-        "keyCertSign",
-        "cRLSign"
-      ],
-      "basic_constraints": {
-        "ca": true
-      }
-    }
+    "extensions": {}
   }
 ]
 ```

--- a/test.py
+++ b/test.py
@@ -8,10 +8,13 @@ BASE_DID = r"did:x509:0:sha256:hH32p4SXlD8n_HLrk_mmNzIKArVh0KkbCeh6eAftfGE::subj
 
 
 def assert_resolved_did_document(doc, expected_did):
+    assert doc["@context"] == "https://www.w3.org/ns/cid/v1"
     assert doc["id"] == expected_did
     assert len(doc["verificationMethod"]) == 1
     assert doc["verificationMethod"][0]["id"] == f"{expected_did}#0"
+    assert doc["verificationMethod"][0]["type"] == "JsonWebKey"
     assert doc["verificationMethod"][0]["controller"] == expected_did
+    assert doc["authentication"] == [f"{expected_did}#0"]
     assert doc["assertionMethod"] == [f"{expected_did}#0"]
     assert doc["keyAgreement"] == [f"{expected_did}#0"]
 


### PR DESCRIPTION
 - Reorganized the specification around the DID method lifecycle:
   - method name and syntax
   - method-specific identifier
   - trust model and `x509chain`
   - certificate-chain JSON model
   - DID Document shape
   - method operations
   - DID resolution
   - security and privacy considerations
   - examples and references
 
 - Replaced the CDDL certificate-chain model with a JSON-focused model that describes the certificate fields used by did:x509 predicate evaluation.
 
 - Clarified the `x509chain` resolution input as a comma-separated list of base64url-encoded DER certificates, ordered leaf first.
 
 - Updated predicate definitions and examples, including:
   - explicit predicate names in ABNF
   - percent-encoding requirements
   - duplicate subject-key rejection in the reference Rego
   - consistent examples using `subject`, `san`, `eku`, and `fulcio-issuer`
 
 - Expanded DID resolution guidance, including certificate-chain validation, critical-extension handling, JSON model mapping, predicate validation, public-key extraction, and DID Document generation.
 
 - Updated the DID Document shape to use:
   - `https://www.w3.org/ns/cid/v1`
   - `JsonWebKey`
   - `publicKeyJwk`
   - `authentication`
   - `assertionMethod`
   - `keyAgreement`
 
 - Added media type guidance for `application/did`, with compatibility notes for `application/did+ld+json` and `application/did+json`.
 
 - Added separate Security and Privacy Considerations sections.
 
 - Updated the Python resolver and tests to match the new DID Document output.